### PR TITLE
Add event for clearTimer

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,17 +28,3 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  publish-gpr:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/components/vidle.ts
+++ b/src/components/vidle.ts
@@ -111,6 +111,7 @@ const Vidle = Vue.extend({
       this.counter = window.setInterval(this.countdown, 1000)
     },
     clearTimer() {
+      this.$emit("clearTimer")
       clearInterval(this.timer)
       clearInterval(this.counter)
       this.setDisplay()


### PR DESCRIPTION
We need to know when the timer was cleared (something happened).

The problem is, when the page is closed, the idle timer is destroyed, so when the page reopens, we dont know how long its been since they've been active.   There are other use cases for this too.

https://github.com/malekim/v-idle/issues/31
